### PR TITLE
Add link to IT Helpdesk contact page

### DIFF
--- a/src/content/docs/laromaterial/kursrepo/organisation.mdx
+++ b/src/content/docs/laromaterial/kursrepo/organisation.mdx
@@ -34,7 +34,7 @@ import organisation3 from '@assets/kursrepo/organisation3.png';
 ## Aktivera Single Sign-On (SSO)
 
 :::note
-Om knappen `Single Sign-On` inte visas, kontrollera att du har genomfört Canvasuppgiften GitHub invite och accepterat inbjudan. Om knappen fortfarande inte visas, kontakta IT Helpdesk och ange din studentmejladress (samma adress som du använde i GitHub invite) samt kurskoden DV1670.
+Om knappen `Single Sign-On` inte visas, kontrollera att du har genomfört Canvasuppgiften GitHub invite och accepterat inbjudan. Om knappen fortfarande inte visas, [kontakta IT Helpdesk](https://www.bth.se/om-bth/kontakta-oss/it-helpdesk) och ange din studentmejladress (samma adress som du använde i GitHub invite) samt kurskoden DV1670.
 :::
 
 När du har accepterat inbjudan till organisationen behöver du aktivera Single Sign-On (SSO) för att kunna arbeta med kursens kod och uppgifter. Klicka på knappen `Single Sign-On` uppe till höger på sidan i organisationen.


### PR DESCRIPTION
Med bakgrund av [detta meddelande i Discord](https://discord.com/channels/118332969004957705/720610462299062364/1542784795363254272) kan det vara en god idé att länka till [IT Helpdesk](https://www.bth.se/om-bth/kontakta-oss/it-helpdesk) för att underlätta för studenterna att hitta rätt vid problem. Länken är en billig försäkring för att studenterna vänder sig till rätt instans för hjälp.

Se före och efter bilder i min lokala miljö:

### Före
<img width="896" height="316" alt="Screenshot 2026-08-28 at 10 34 51" src="https://github.com/user-attachments/assets/2ea34ee9-4e67-451a-95dc-bb9599b35c18" />

### Efter
<img width="896" height="316" alt="Screenshot 2026-08-28 at 10 35 32" src="https://github.com/user-attachments/assets/a2bf90e0-17a6-4697-bc1a-c6dd184bbeca" />